### PR TITLE
Implement authorization to ensure that users can only assign badges t…

### DIFF
--- a/internal/handlers/badge.go
+++ b/internal/handlers/badge.go
@@ -109,39 +109,58 @@ func GetUserBadgeByIDHandler(c *gin.Context) {
 }
 
 func AssignBadgeHandler(c *gin.Context) {
+    type AssignBadgeReq struct {
+        UserID        string `json:"user_id"`
+        BadgeID       uint   `json:"badge_id"`
+        AssessmentID  uint   `json:"assessment_id"`
+    }
 
-	type AssignBadgeReq struct {
-		UserID string `json:"user_id"`
-		AssessmentID uint `json:"assessment_id"`
-	}
+    loggedInUserID, exists := c.Get("loggedInUserID")
+    if !exists {
+        response.Error(c, http.StatusUnauthorized, "Unauthorized access", map[string]interface{}{
+            "error": "Authentication required",
+        })
+        return
+    }
 
-	var body AssignBadgeReq
+    var body AssignBadgeReq
+    if err := c.ShouldBindJSON(&body); err != nil {
+        response.Error(c, http.StatusBadRequest, fmt.Sprintf("Invalid request body: %s", err.Error()), map[string]interface{}{})
+        return
+    }
 
-	if err := c.ShouldBindJSON(&body); err != nil {
-		response.Error(c, http.StatusBadRequest, fmt.Sprintf("Invalid request body: %s", err.Error()), map[string]interface{}{})
-		return
-	}
+    if loggedInUserID != body.UserID {
+        response.Error(c, http.StatusUnauthorized, "Unauthorized access", map[string]interface{}{
+            "error": "You are not authorized to assign badges to other users",
+        })
+        return
+    }
 
-	isValidAssessment:= models.VerifyAssessment(db.DB, body.AssessmentID)
+    isValidBadge := models.CheckIfBadgeIsValid(db.DB, body.BadgeID)
+    if !isValidBadge {
+        response.Error(c, http.StatusBadRequest, "This is not a valid badge", map[string]interface{}{
+            "error": "This badge does not exist or is not a valid badge",
+        })
+        return
+    }
 
-	if !isValidAssessment {
-		response.Error(c, http.StatusBadRequest, "Invalid Assessment", map[string]interface{}{
-			"error": "This assessment is not valid or is under review",
-		})
-		return
-	}
+    isValidAssessment := models.VerifyAssessment(db.DB, body.AssessmentID)
+    if !isValidAssessment {
+        response.Error(c, http.StatusBadRequest, "Invalid Assessment", map[string]interface{}{
+            "error": "This assessment is not valid or is under review",
+        })
+        return
+    }
 
-	userBadge, err:= models.AssignBadge(db.DB, body.UserID, body.AssessmentID)
+    userBadge, err := models.AssignBadge(db.DB, body.UserID, body.BadgeID, body.AssessmentID)
+    if err != nil {
+        response.Error(c, http.StatusInternalServerError, "Unable to assign badge", map[string]interface{}{
+            "err": err.Error(),
+        })
+        return
+    }
 
-	if err != nil {
-		response.Error(c, http.StatusInternalServerError, "Unable to assign badge", map[string]interface{}{
-			"err": err.Error(),
-		})
-
-		return
-	}
-
-	response.Success(c, http.StatusCreated, "Badge Assigned Successfully", map[string]interface{}{
-		"badge": userBadge,
-	})
+    response.Success(c, http.StatusCreated, "Badge Assigned Successfully", map[string]interface{}{
+        "badge": userBadge,
+    })
 }


### PR DESCRIPTION
…o themselves.

Added a check to ensure that the loggedInUserID (obtained from the authentication middleware) matches the UserID provided in the request


## Motivation and Context
- It enforces the rule that users can only assign badges to themselves and prevent unauthorized badge assignments to other users.

## Changes Made

- Changed bagde.go to enforce the rule that users can only assign badges to themselves and prevent unauthorized badge assignments to other users.

## Checklist

<!-- Mark the following items with "x" to confirm that they have been completed. -->

- [x] My code follows the project's code style.
- [ ] I have reviewed the changes and tested them thoroughly.
- [x] Documentation has been updated to reflect the changes.
- [x] The PR title is clear and descriptive.
- [x] The PR is associated with a relevant issue.
- [ ] All tests pass, and new tests have been added where necessary.

