### PR TITLE
fix: Authorization header parsing issue

### DIFF
--- a/internal/middleware/viewbadgeauth.go
+++ b/internal/middleware/viewbadgeauth.go
@@ -33,6 +33,13 @@ func CanViewBadge() gin.HandlerFunc {
 		}
 
 		body.Token = strings.Split(token, " ")[1]
+		if body.Token == "" {
+			response.Error(c, http.StatusUnauthorized, "Specify a bearer token", map[string]interface{}{
+				"Auth": "Authorization header is missing or improperly formatted",
+			})
+			c.Abort()
+			return
+		}
 		body.Permission = "badge.read"
 
 		client := resty.New().R()


### PR DESCRIPTION
Fixes an issue where the middleware was encountering an "index out of range" error due to improper parsing of the Authorization header. The error occurred when the header was missing or not formatted correctly. This pull request adds a check for a valid Authorization header before attempting to split it, preventing the error from occurring.

_Server Error message before fix._
```
runtime error: index out of range [1] with length 1
/nix/store/hxvbx812hcd8ci4rcx66ipb958g77gp8-go-1.20.8/share/go/src/runtime/panic.go:113 (0x43347e)
/app/internal/middleware/viewbadgeauth.go:26 (0xb82073)
CanViewBadge.func1: body.Token = strings.Split(token, " ")[1]
```