### PR TITLE
Verify user id and badge id.

### DIFF
--- a/internal/handlers/badge.go
+++ b/internal/handlers/badge.go
@@ -5,10 +5,11 @@ import (
 	"demerzel-badges/internal/models"
 	"demerzel-badges/pkg/response"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/go-resty/resty/v2"
 	"net/http"
 	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-resty/resty/v2"
 )
 
 func CreateBadgeHandler(c *gin.Context) {
@@ -119,16 +120,19 @@ func GetUserBadgeByIDHandler(c *gin.Context) {
 		response.Error(c, http.StatusBadRequest, "Invalid badgeID", map[string]interface{}{})
 		return
 	}
-	badge, err := models.GetUserBadgeByID(db.DB, uint(badgeID))
+
+	userId := c.GetString("user_id")
+	badge, err := models.GetUserBadgeByID(db.DB, uint(badgeID), userId)
 	if err != nil {
-		response.Error(c, http.StatusNotFound, "Badge Not found", map[string]string{})
+		response.Error(c, http.StatusNotFound, "Badge Not found", map[string]interface{}{
+			"error": err.Error(),
+		})
 		return
 	}
 
 	response.Success(c, http.StatusOK, "User Badge", map[string]interface{}{
 		"badge": badge,
 	})
-	return
 }
 
 func AssignBadgeHandler(c *gin.Context) {

--- a/internal/models/badge.go
+++ b/internal/models/badge.go
@@ -175,14 +175,15 @@ func VerifyAssessment(db *gorm.DB, asssessmentID uint) bool {
 	return err == nil
 }
 
-func GetUserBadgeByID(db *gorm.DB, badgeID uint) (*UserBadge, error) {
+func GetUserBadgeByID(db *gorm.DB, badgeID uint, userID string) (*UserBadge, error) {
 	var badge UserBadge
-	result := db.Model(&UserBadge{}).Where("id = ?", badgeID).Preload("UserAssessment").
+	result := db.Where(&UserBadge{ID: badgeID, UserID: userID}).
 		Preload("User").
 		Preload("Badge").
 		Preload("UserAssessment.Assessment").
 		Preload("Badge.Skill").
 		First(&badge)
+
 	if result.Error != nil {
 		return nil, result.Error
 	}


### PR DESCRIPTION
## Description
A user could access another user's badge by just supplying any badge ID to the request URL and could download it as his/her own, there was no way to check if the badge was the user's own.
_Request Endpoint:_
GET  `/api/badges/badges/:badge_id`
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Security issues:  a user could forge another user's badge as his.
​​
## Screenshots (if appropriate - Postman, etc):
![Screenshot from 2023-10-20 14-02-25](https://github.com/hngx-org/demerzel-badges/assets/102483755/709226be-86ae-43e8-afec-89cb09666ef8)
Here I'm logged in as `Promise`, but I could access `Team Empire`'s badge, as seen in the console.
Now such a request gets this response:
```json
{
  "errors": {
    "error": "record not found"
  },
  "message": "Badge Not found",
  "status": "error"
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.