### PR TITLE
ptch:  refactor endpoint to use new messaging url

### DIFF
--- a/internal/handlers/badge.go
+++ b/internal/handlers/badge.go
@@ -189,7 +189,7 @@ func AssignBadgeHandler(c *gin.Context) {
 	client := resty.New().R()
 	client.SetHeader("Content-Type", "application/json")
 	client.SetBody(&emailReq)
-	res, err := client.Post("https://team-titan.mrprotocoll.me/api/messaging/assessment/badge")
+	res, err := client.Post("https://team-titan.mrprotocoll.me/api/v1/messaging/assessment/badge")
 
 	if err != nil {
 		response.Error(c, 500, "Something went wrong", err)


### PR DESCRIPTION
The change refactors the assign badge endpoint to use the new messaging URL